### PR TITLE
Update compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -35,3 +35,13 @@ if [[ -f "${APP_DIR}/runtime.txt" ]]; then
     cp "${APP_DIR}/runtime.txt" "${BUILD_DIR}/runtime.txt"
     echo "Copied ${APP_DIR}/runtime.txt as runtime.txt successfully" | indent
 fi
+
+if [[ -f "${APP_DIR}/Pipfile" ]]; then
+    cp "${APP_DIR}/Pipfile" "${BUILD_DIR}/Pipfile"
+    echo "Copied ${APP_DIR}/Pipfile as Pipfile successfully" | indent
+fi
+
+if [[ -f "${APP_DIR}/Pipfile.lock" ]]; then
+    cp "${APP_DIR}/Pipfile.lock" "${BUILD_DIR}/Pipfile.lock"
+    echo "Copied ${APP_DIR}/Pipfile.lock as Pipfile.lock successfully" | indent
+fi


### PR DESCRIPTION
This will be required if we switch to pipenv as pipenv does not utilize a "runtime.txt" or a "requirements.txt" file, instead these dependencies are handled via our Pipfile and Pipfile.lock.

See:
https://towardsdatascience.com/pipenv-to-heroku-easy-app-deployment-1c60b0e50996

According to this- Heroku will first attempt to find a requirements.txt file, and upon failure will automatically attempt to install requirements from a Pipfile.lock file, which is the desired behavior.